### PR TITLE
feat: add typed transport config

### DIFF
--- a/gen/go/proto/transport/v1/proto_roundtrip_test.go
+++ b/gen/go/proto/transport/v1/proto_roundtrip_test.go
@@ -99,6 +99,33 @@ func TestDataRequestRoundTripComplexStructuredContext(t *testing.T) {
 	})
 }
 
+func TestDataRequestRoundTripTypedTransportConfig(t *testing.T) {
+	legacyCfg, err := structpb.NewStruct(map[string]any{
+		"transportRef": "livekit",
+		"modeReason":   "status-selected",
+	})
+	if err != nil {
+		t.Fatalf("legacy config struct: %v", err)
+	}
+
+	roundTripDataRequest(t, &DataRequest{
+		Frame: &DataRequest_Binary{Binary: &BinaryFrame{
+			Payload:  []byte(`{"ok":true}`),
+			MimeType: "application/json",
+		}},
+		Transports: []*TransportDescriptor{{
+			Name:   "primary",
+			Kind:   "grpc",
+			Mode:   "hot",
+			Config: legacyCfg,
+			TypedConfig: &TransportConfig{
+				TransportRef: "livekit",
+				ModeReason:   "status-selected",
+			},
+		}},
+	})
+}
+
 func TestControlRequestRoundTripAllActions(t *testing.T) {
 	for name, value := range ControlAction_value {
 		action := ControlAction(value)

--- a/gen/go/proto/transport/v1/proto_validate_test.go
+++ b/gen/go/proto/transport/v1/proto_validate_test.go
@@ -53,6 +53,19 @@ func TestProtovalidateRejectsInvalidTransportMessages(t *testing.T) {
 		"data packet transports too many": &DataPacket{
 			Transports: manyTransportDescriptors(11),
 		},
+		"transport typed config transport ref too long": &TransportDescriptor{
+			Name: "primary",
+			TypedConfig: &TransportConfig{
+				TransportRef: strings.Repeat("t", 254),
+			},
+		},
+		"transport typed config mode reason too long": &TransportDescriptor{
+			Name: "primary",
+			TypedConfig: &TransportConfig{
+				TransportRef: "livekit",
+				ModeReason:   strings.Repeat("m", 513),
+			},
+		},
 		"partition acks too many": &FlowControl{
 			PartitionAcks: manyPartitionAcks(257),
 		},

--- a/gen/go/proto/transport/v1/transport.pb.go
+++ b/gen/go/proto/transport/v1/transport.pb.go
@@ -514,7 +514,16 @@ type TransportDescriptor struct {
 	// mode identifies how the transport is used (for example, hot vs cold path).
 	Mode string `protobuf:"bytes,3,opt,name=mode,proto3" json:"mode,omitempty"`
 	// config contains transport-specific configuration surfaced to consumers.
-	Config        *structpb.Struct `protobuf:"bytes,4,opt,name=config,proto3" json:"config,omitempty"`
+	// It is retained for compatibility with older producers and consumers. New
+	// consumers should prefer typed_config when present and must not use config
+	// values directly for connection, TLS, credential, or endpoint decisions
+	// without an allowlisted downstream validation step.
+	Config *structpb.Struct `protobuf:"bytes,4,opt,name=config,proto3" json:"config,omitempty"`
+	// typed_config carries bounded runtime descriptor metadata. It intentionally
+	// excludes provider connection directives such as endpoints, credentials, or
+	// TLS-disable flags; those settings belong in validated operator-owned
+	// Transport/TransportBinding configuration, not in per-packet descriptors.
+	TypedConfig   *TransportConfig `protobuf:"bytes,5,opt,name=typed_config,json=typedConfig,proto3" json:"typed_config,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -577,6 +586,68 @@ func (x *TransportDescriptor) GetConfig() *structpb.Struct {
 	return nil
 }
 
+func (x *TransportDescriptor) GetTypedConfig() *TransportConfig {
+	if x != nil {
+		return x.TypedConfig
+	}
+	return nil
+}
+
+// TransportConfig carries safe, typed runtime descriptor metadata.
+type TransportConfig struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// transport_ref identifies the Transport resource that produced this descriptor.
+	TransportRef string `protobuf:"bytes,1,opt,name=transport_ref,json=transportRef,proto3" json:"transport_ref,omitempty"`
+	// mode_reason explains why the runtime selected the descriptor mode.
+	ModeReason    string `protobuf:"bytes,2,opt,name=mode_reason,json=modeReason,proto3" json:"mode_reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransportConfig) Reset() {
+	*x = TransportConfig{}
+	mi := &file_transport_v1_transport_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransportConfig) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransportConfig) ProtoMessage() {}
+
+func (x *TransportConfig) ProtoReflect() protoreflect.Message {
+	mi := &file_transport_v1_transport_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransportConfig.ProtoReflect.Descriptor instead.
+func (*TransportConfig) Descriptor() ([]byte, []int) {
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *TransportConfig) GetTransportRef() string {
+	if x != nil {
+		return x.TransportRef
+	}
+	return ""
+}
+
+func (x *TransportConfig) GetModeReason() string {
+	if x != nil {
+		return x.ModeReason
+	}
+	return ""
+}
+
 // PublishRequest carries a packet plus structured context for pub/sub style publishers.
 type PublishRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -604,7 +675,7 @@ type PublishRequest struct {
 
 func (x *PublishRequest) Reset() {
 	*x = PublishRequest{}
-	mi := &file_transport_v1_transport_proto_msgTypes[4]
+	mi := &file_transport_v1_transport_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -616,7 +687,7 @@ func (x *PublishRequest) String() string {
 func (*PublishRequest) ProtoMessage() {}
 
 func (x *PublishRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[4]
+	mi := &file_transport_v1_transport_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -629,7 +700,7 @@ func (x *PublishRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishRequest.ProtoReflect.Descriptor instead.
 func (*PublishRequest) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{4}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *PublishRequest) GetFrame() isPublishRequest_Frame {
@@ -743,7 +814,7 @@ type ControlRequest struct {
 
 func (x *ControlRequest) Reset() {
 	*x = ControlRequest{}
-	mi := &file_transport_v1_transport_proto_msgTypes[5]
+	mi := &file_transport_v1_transport_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -755,7 +826,7 @@ func (x *ControlRequest) String() string {
 func (*ControlRequest) ProtoMessage() {}
 
 func (x *ControlRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[5]
+	mi := &file_transport_v1_transport_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -768,7 +839,7 @@ func (x *ControlRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlRequest.ProtoReflect.Descriptor instead.
 func (*ControlRequest) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{5}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ControlRequest) GetAction() ControlAction {
@@ -815,7 +886,7 @@ type ControlError struct {
 
 func (x *ControlError) Reset() {
 	*x = ControlError{}
-	mi := &file_transport_v1_transport_proto_msgTypes[6]
+	mi := &file_transport_v1_transport_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -827,7 +898,7 @@ func (x *ControlError) String() string {
 func (*ControlError) ProtoMessage() {}
 
 func (x *ControlError) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[6]
+	mi := &file_transport_v1_transport_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -840,7 +911,7 @@ func (x *ControlError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlError.ProtoReflect.Descriptor instead.
 func (*ControlError) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{6}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ControlError) GetCode() int32 {
@@ -883,7 +954,7 @@ type ControlResponse struct {
 
 func (x *ControlResponse) Reset() {
 	*x = ControlResponse{}
-	mi := &file_transport_v1_transport_proto_msgTypes[7]
+	mi := &file_transport_v1_transport_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -895,7 +966,7 @@ func (x *ControlResponse) String() string {
 func (*ControlResponse) ProtoMessage() {}
 
 func (x *ControlResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[7]
+	mi := &file_transport_v1_transport_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -908,7 +979,7 @@ func (x *ControlResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ControlResponse.ProtoReflect.Descriptor instead.
 func (*ControlResponse) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{7}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ControlResponse) GetAction() ControlAction {
@@ -959,7 +1030,7 @@ type PartitionAck struct {
 
 func (x *PartitionAck) Reset() {
 	*x = PartitionAck{}
-	mi := &file_transport_v1_transport_proto_msgTypes[8]
+	mi := &file_transport_v1_transport_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -971,7 +1042,7 @@ func (x *PartitionAck) String() string {
 func (*PartitionAck) ProtoMessage() {}
 
 func (x *PartitionAck) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[8]
+	mi := &file_transport_v1_transport_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -984,7 +1055,7 @@ func (x *PartitionAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PartitionAck.ProtoReflect.Descriptor instead.
 func (*PartitionAck) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{8}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *PartitionAck) GetPartition() string {
@@ -1020,7 +1091,7 @@ type FlowControl struct {
 
 func (x *FlowControl) Reset() {
 	*x = FlowControl{}
-	mi := &file_transport_v1_transport_proto_msgTypes[9]
+	mi := &file_transport_v1_transport_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1032,7 +1103,7 @@ func (x *FlowControl) String() string {
 func (*FlowControl) ProtoMessage() {}
 
 func (x *FlowControl) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[9]
+	mi := &file_transport_v1_transport_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1045,7 +1116,7 @@ func (x *FlowControl) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FlowControl.ProtoReflect.Descriptor instead.
 func (*FlowControl) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{9}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *FlowControl) GetAck() uint64 {
@@ -1112,7 +1183,7 @@ type StreamEnvelope struct {
 
 func (x *StreamEnvelope) Reset() {
 	*x = StreamEnvelope{}
-	mi := &file_transport_v1_transport_proto_msgTypes[10]
+	mi := &file_transport_v1_transport_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1124,7 +1195,7 @@ func (x *StreamEnvelope) String() string {
 func (*StreamEnvelope) ProtoMessage() {}
 
 func (x *StreamEnvelope) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[10]
+	mi := &file_transport_v1_transport_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1137,7 +1208,7 @@ func (x *StreamEnvelope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamEnvelope.ProtoReflect.Descriptor instead.
 func (*StreamEnvelope) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{10}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *StreamEnvelope) GetStreamId() string {
@@ -1221,7 +1292,7 @@ type BindingInfo struct {
 
 func (x *BindingInfo) Reset() {
 	*x = BindingInfo{}
-	mi := &file_transport_v1_transport_proto_msgTypes[11]
+	mi := &file_transport_v1_transport_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1233,7 +1304,7 @@ func (x *BindingInfo) String() string {
 func (*BindingInfo) ProtoMessage() {}
 
 func (x *BindingInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[11]
+	mi := &file_transport_v1_transport_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1246,7 +1317,7 @@ func (x *BindingInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BindingInfo.ProtoReflect.Descriptor instead.
 func (*BindingInfo) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{11}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *BindingInfo) GetTransportRef() string {
@@ -1332,7 +1403,7 @@ type DataRequest struct {
 
 func (x *DataRequest) Reset() {
 	*x = DataRequest{}
-	mi := &file_transport_v1_transport_proto_msgTypes[12]
+	mi := &file_transport_v1_transport_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1344,7 +1415,7 @@ func (x *DataRequest) String() string {
 func (*DataRequest) ProtoMessage() {}
 
 func (x *DataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[12]
+	mi := &file_transport_v1_transport_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1357,7 +1428,7 @@ func (x *DataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataRequest.ProtoReflect.Descriptor instead.
 func (*DataRequest) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{12}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DataRequest) GetFrame() isDataRequest_Frame {
@@ -1481,7 +1552,7 @@ type DataResponse struct {
 
 func (x *DataResponse) Reset() {
 	*x = DataResponse{}
-	mi := &file_transport_v1_transport_proto_msgTypes[13]
+	mi := &file_transport_v1_transport_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1493,7 +1564,7 @@ func (x *DataResponse) String() string {
 func (*DataResponse) ProtoMessage() {}
 
 func (x *DataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[13]
+	mi := &file_transport_v1_transport_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1506,7 +1577,7 @@ func (x *DataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataResponse.ProtoReflect.Descriptor instead.
 func (*DataResponse) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{13}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DataResponse) GetFrame() isDataResponse_Frame {
@@ -1630,7 +1701,7 @@ type HubPushRequest struct {
 
 func (x *HubPushRequest) Reset() {
 	*x = HubPushRequest{}
-	mi := &file_transport_v1_transport_proto_msgTypes[14]
+	mi := &file_transport_v1_transport_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1642,7 +1713,7 @@ func (x *HubPushRequest) String() string {
 func (*HubPushRequest) ProtoMessage() {}
 
 func (x *HubPushRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[14]
+	mi := &file_transport_v1_transport_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1655,7 +1726,7 @@ func (x *HubPushRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HubPushRequest.ProtoReflect.Descriptor instead.
 func (*HubPushRequest) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{14}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *HubPushRequest) GetMetadata() map[string]string {
@@ -1779,7 +1850,7 @@ type HubPushResponse struct {
 
 func (x *HubPushResponse) Reset() {
 	*x = HubPushResponse{}
-	mi := &file_transport_v1_transport_proto_msgTypes[15]
+	mi := &file_transport_v1_transport_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1791,7 +1862,7 @@ func (x *HubPushResponse) String() string {
 func (*HubPushResponse) ProtoMessage() {}
 
 func (x *HubPushResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_transport_v1_transport_proto_msgTypes[15]
+	mi := &file_transport_v1_transport_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1804,7 +1875,7 @@ func (x *HubPushResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HubPushResponse.ProtoReflect.Descriptor instead.
 func (*HubPushResponse) Descriptor() ([]byte, []int) {
-	return file_transport_v1_transport_proto_rawDescGZIP(), []int{15}
+	return file_transport_v1_transport_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *HubPushResponse) GetMetadata() map[string]string {
@@ -1927,12 +1998,17 @@ const file_transport_v1_transport_proto_rawDesc = "" +
 	"\apayload\x18\x01 \x01(\fB\n" +
 	"\xbaH\az\x05\x18\x80\x80\x80\x05R\apayload\x12%\n" +
 	"\tmime_type\x18\x02 \x01(\tB\b\xbaH\x05r\x03\x18\xff\x01R\bmimeType\x12!\n" +
-	"\ftimestamp_ms\x18\x03 \x01(\x04R\vtimestampMs\"\xa0\x01\n" +
+	"\ftimestamp_ms\x18\x03 \x01(\x04R\vtimestampMs\"\xe2\x01\n" +
 	"\x13TransportDescriptor\x12\x1c\n" +
 	"\x04name\x18\x01 \x01(\tB\b\xbaH\x05r\x03\x18\x80\x01R\x04name\x12\x1c\n" +
 	"\x04kind\x18\x02 \x01(\tB\b\xbaH\x05r\x03\x18\x80\x01R\x04kind\x12\x1c\n" +
 	"\x04mode\x18\x03 \x01(\tB\b\xbaH\x05r\x03\x18\x80\x01R\x04mode\x12/\n" +
-	"\x06config\x18\x04 \x01(\v2\x17.google.protobuf.StructR\x06config\"\xbc\x04\n" +
+	"\x06config\x18\x04 \x01(\v2\x17.google.protobuf.StructR\x06config\x12@\n" +
+	"\ftyped_config\x18\x05 \x01(\v2\x1d.transport.v1.TransportConfigR\vtypedConfig\"k\n" +
+	"\x0fTransportConfig\x12-\n" +
+	"\rtransport_ref\x18\x01 \x01(\tB\b\xbaH\x05r\x03\x18\xfd\x01R\ftransportRef\x12)\n" +
+	"\vmode_reason\x18\x02 \x01(\tB\b\xbaH\x05r\x03\x18\x80\x04R\n" +
+	"modeReason\"\xbc\x04\n" +
 	"\x0ePublishRequest\x120\n" +
 	"\x05audio\x18\x01 \x01(\v2\x18.transport.v1.AudioFrameH\x00R\x05audio\x120\n" +
 	"\x05video\x18\x02 \x01(\v2\x18.transport.v1.VideoFrameH\x00R\x05video\x123\n" +
@@ -2133,7 +2209,7 @@ func file_transport_v1_transport_proto_rawDescGZIP() []byte {
 }
 
 var file_transport_v1_transport_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_transport_v1_transport_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_transport_v1_transport_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_transport_v1_transport_proto_goTypes = []any{
 	(ControlAction)(0),          // 0: transport.v1.ControlAction
 	(FlowControlSignal)(0),      // 1: transport.v1.FlowControlSignal
@@ -2142,91 +2218,93 @@ var file_transport_v1_transport_proto_goTypes = []any{
 	(*VideoFrame)(nil),          // 4: transport.v1.VideoFrame
 	(*BinaryFrame)(nil),         // 5: transport.v1.BinaryFrame
 	(*TransportDescriptor)(nil), // 6: transport.v1.TransportDescriptor
-	(*PublishRequest)(nil),      // 7: transport.v1.PublishRequest
-	(*ControlRequest)(nil),      // 8: transport.v1.ControlRequest
-	(*ControlError)(nil),        // 9: transport.v1.ControlError
-	(*ControlResponse)(nil),     // 10: transport.v1.ControlResponse
-	(*PartitionAck)(nil),        // 11: transport.v1.PartitionAck
-	(*FlowControl)(nil),         // 12: transport.v1.FlowControl
-	(*StreamEnvelope)(nil),      // 13: transport.v1.StreamEnvelope
-	(*BindingInfo)(nil),         // 14: transport.v1.BindingInfo
-	(*DataRequest)(nil),         // 15: transport.v1.DataRequest
-	(*DataResponse)(nil),        // 16: transport.v1.DataResponse
-	(*HubPushRequest)(nil),      // 17: transport.v1.HubPushRequest
-	(*HubPushResponse)(nil),     // 18: transport.v1.HubPushResponse
-	nil,                         // 19: transport.v1.PublishRequest.MetadataEntry
-	nil,                         // 20: transport.v1.ControlRequest.MetadataEntry
-	nil,                         // 21: transport.v1.ControlError.DetailsEntry
-	nil,                         // 22: transport.v1.ControlResponse.MetadataEntry
-	nil,                         // 23: transport.v1.DataRequest.MetadataEntry
-	nil,                         // 24: transport.v1.DataResponse.MetadataEntry
-	nil,                         // 25: transport.v1.HubPushRequest.MetadataEntry
-	nil,                         // 26: transport.v1.HubPushResponse.MetadataEntry
-	(*structpb.Struct)(nil),     // 27: google.protobuf.Struct
+	(*TransportConfig)(nil),     // 7: transport.v1.TransportConfig
+	(*PublishRequest)(nil),      // 8: transport.v1.PublishRequest
+	(*ControlRequest)(nil),      // 9: transport.v1.ControlRequest
+	(*ControlError)(nil),        // 10: transport.v1.ControlError
+	(*ControlResponse)(nil),     // 11: transport.v1.ControlResponse
+	(*PartitionAck)(nil),        // 12: transport.v1.PartitionAck
+	(*FlowControl)(nil),         // 13: transport.v1.FlowControl
+	(*StreamEnvelope)(nil),      // 14: transport.v1.StreamEnvelope
+	(*BindingInfo)(nil),         // 15: transport.v1.BindingInfo
+	(*DataRequest)(nil),         // 16: transport.v1.DataRequest
+	(*DataResponse)(nil),        // 17: transport.v1.DataResponse
+	(*HubPushRequest)(nil),      // 18: transport.v1.HubPushRequest
+	(*HubPushResponse)(nil),     // 19: transport.v1.HubPushResponse
+	nil,                         // 20: transport.v1.PublishRequest.MetadataEntry
+	nil,                         // 21: transport.v1.ControlRequest.MetadataEntry
+	nil,                         // 22: transport.v1.ControlError.DetailsEntry
+	nil,                         // 23: transport.v1.ControlResponse.MetadataEntry
+	nil,                         // 24: transport.v1.DataRequest.MetadataEntry
+	nil,                         // 25: transport.v1.DataResponse.MetadataEntry
+	nil,                         // 26: transport.v1.HubPushRequest.MetadataEntry
+	nil,                         // 27: transport.v1.HubPushResponse.MetadataEntry
+	(*structpb.Struct)(nil),     // 28: google.protobuf.Struct
 }
 var file_transport_v1_transport_proto_depIdxs = []int32{
-	27, // 0: transport.v1.TransportDescriptor.config:type_name -> google.protobuf.Struct
-	3,  // 1: transport.v1.PublishRequest.audio:type_name -> transport.v1.AudioFrame
-	4,  // 2: transport.v1.PublishRequest.video:type_name -> transport.v1.VideoFrame
-	5,  // 3: transport.v1.PublishRequest.binary:type_name -> transport.v1.BinaryFrame
-	19, // 4: transport.v1.PublishRequest.metadata:type_name -> transport.v1.PublishRequest.MetadataEntry
-	27, // 5: transport.v1.PublishRequest.payload:type_name -> google.protobuf.Struct
-	27, // 6: transport.v1.PublishRequest.inputs:type_name -> google.protobuf.Struct
-	6,  // 7: transport.v1.PublishRequest.transports:type_name -> transport.v1.TransportDescriptor
-	13, // 8: transport.v1.PublishRequest.envelope:type_name -> transport.v1.StreamEnvelope
-	0,  // 9: transport.v1.ControlRequest.action:type_name -> transport.v1.ControlAction
-	20, // 10: transport.v1.ControlRequest.metadata:type_name -> transport.v1.ControlRequest.MetadataEntry
-	12, // 11: transport.v1.ControlRequest.flow:type_name -> transport.v1.FlowControl
-	21, // 12: transport.v1.ControlError.details:type_name -> transport.v1.ControlError.DetailsEntry
-	0,  // 13: transport.v1.ControlResponse.action:type_name -> transport.v1.ControlAction
-	22, // 14: transport.v1.ControlResponse.metadata:type_name -> transport.v1.ControlResponse.MetadataEntry
-	12, // 15: transport.v1.ControlResponse.flow:type_name -> transport.v1.FlowControl
-	9,  // 16: transport.v1.ControlResponse.error:type_name -> transport.v1.ControlError
-	11, // 17: transport.v1.FlowControl.partition_acks:type_name -> transport.v1.PartitionAck
-	1,  // 18: transport.v1.FlowControl.signal:type_name -> transport.v1.FlowControlSignal
-	3,  // 19: transport.v1.DataRequest.audio:type_name -> transport.v1.AudioFrame
-	4,  // 20: transport.v1.DataRequest.video:type_name -> transport.v1.VideoFrame
-	5,  // 21: transport.v1.DataRequest.binary:type_name -> transport.v1.BinaryFrame
-	23, // 22: transport.v1.DataRequest.metadata:type_name -> transport.v1.DataRequest.MetadataEntry
-	27, // 23: transport.v1.DataRequest.payload:type_name -> google.protobuf.Struct
-	27, // 24: transport.v1.DataRequest.inputs:type_name -> google.protobuf.Struct
-	6,  // 25: transport.v1.DataRequest.transports:type_name -> transport.v1.TransportDescriptor
-	13, // 26: transport.v1.DataRequest.envelope:type_name -> transport.v1.StreamEnvelope
-	3,  // 27: transport.v1.DataResponse.audio:type_name -> transport.v1.AudioFrame
-	4,  // 28: transport.v1.DataResponse.video:type_name -> transport.v1.VideoFrame
-	5,  // 29: transport.v1.DataResponse.binary:type_name -> transport.v1.BinaryFrame
-	24, // 30: transport.v1.DataResponse.metadata:type_name -> transport.v1.DataResponse.MetadataEntry
-	27, // 31: transport.v1.DataResponse.payload:type_name -> google.protobuf.Struct
-	27, // 32: transport.v1.DataResponse.inputs:type_name -> google.protobuf.Struct
-	6,  // 33: transport.v1.DataResponse.transports:type_name -> transport.v1.TransportDescriptor
-	13, // 34: transport.v1.DataResponse.envelope:type_name -> transport.v1.StreamEnvelope
-	25, // 35: transport.v1.HubPushRequest.metadata:type_name -> transport.v1.HubPushRequest.MetadataEntry
-	27, // 36: transport.v1.HubPushRequest.payload:type_name -> google.protobuf.Struct
-	27, // 37: transport.v1.HubPushRequest.inputs:type_name -> google.protobuf.Struct
-	3,  // 38: transport.v1.HubPushRequest.audio:type_name -> transport.v1.AudioFrame
-	4,  // 39: transport.v1.HubPushRequest.video:type_name -> transport.v1.VideoFrame
-	5,  // 40: transport.v1.HubPushRequest.binary:type_name -> transport.v1.BinaryFrame
-	6,  // 41: transport.v1.HubPushRequest.transports:type_name -> transport.v1.TransportDescriptor
-	13, // 42: transport.v1.HubPushRequest.envelope:type_name -> transport.v1.StreamEnvelope
-	26, // 43: transport.v1.HubPushResponse.metadata:type_name -> transport.v1.HubPushResponse.MetadataEntry
-	27, // 44: transport.v1.HubPushResponse.payload:type_name -> google.protobuf.Struct
-	27, // 45: transport.v1.HubPushResponse.inputs:type_name -> google.protobuf.Struct
-	6,  // 46: transport.v1.HubPushResponse.transports:type_name -> transport.v1.TransportDescriptor
-	3,  // 47: transport.v1.HubPushResponse.audio:type_name -> transport.v1.AudioFrame
-	4,  // 48: transport.v1.HubPushResponse.video:type_name -> transport.v1.VideoFrame
-	5,  // 49: transport.v1.HubPushResponse.binary:type_name -> transport.v1.BinaryFrame
-	13, // 50: transport.v1.HubPushResponse.envelope:type_name -> transport.v1.StreamEnvelope
-	15, // 51: transport.v1.TransportConnectorService.Data:input_type -> transport.v1.DataRequest
-	8,  // 52: transport.v1.TransportConnectorService.Control:input_type -> transport.v1.ControlRequest
-	17, // 53: transport.v1.TransportConnectorService.HubPush:input_type -> transport.v1.HubPushRequest
-	16, // 54: transport.v1.TransportConnectorService.Data:output_type -> transport.v1.DataResponse
-	10, // 55: transport.v1.TransportConnectorService.Control:output_type -> transport.v1.ControlResponse
-	18, // 56: transport.v1.TransportConnectorService.HubPush:output_type -> transport.v1.HubPushResponse
-	54, // [54:57] is the sub-list for method output_type
-	51, // [51:54] is the sub-list for method input_type
-	51, // [51:51] is the sub-list for extension type_name
-	51, // [51:51] is the sub-list for extension extendee
-	0,  // [0:51] is the sub-list for field type_name
+	28, // 0: transport.v1.TransportDescriptor.config:type_name -> google.protobuf.Struct
+	7,  // 1: transport.v1.TransportDescriptor.typed_config:type_name -> transport.v1.TransportConfig
+	3,  // 2: transport.v1.PublishRequest.audio:type_name -> transport.v1.AudioFrame
+	4,  // 3: transport.v1.PublishRequest.video:type_name -> transport.v1.VideoFrame
+	5,  // 4: transport.v1.PublishRequest.binary:type_name -> transport.v1.BinaryFrame
+	20, // 5: transport.v1.PublishRequest.metadata:type_name -> transport.v1.PublishRequest.MetadataEntry
+	28, // 6: transport.v1.PublishRequest.payload:type_name -> google.protobuf.Struct
+	28, // 7: transport.v1.PublishRequest.inputs:type_name -> google.protobuf.Struct
+	6,  // 8: transport.v1.PublishRequest.transports:type_name -> transport.v1.TransportDescriptor
+	14, // 9: transport.v1.PublishRequest.envelope:type_name -> transport.v1.StreamEnvelope
+	0,  // 10: transport.v1.ControlRequest.action:type_name -> transport.v1.ControlAction
+	21, // 11: transport.v1.ControlRequest.metadata:type_name -> transport.v1.ControlRequest.MetadataEntry
+	13, // 12: transport.v1.ControlRequest.flow:type_name -> transport.v1.FlowControl
+	22, // 13: transport.v1.ControlError.details:type_name -> transport.v1.ControlError.DetailsEntry
+	0,  // 14: transport.v1.ControlResponse.action:type_name -> transport.v1.ControlAction
+	23, // 15: transport.v1.ControlResponse.metadata:type_name -> transport.v1.ControlResponse.MetadataEntry
+	13, // 16: transport.v1.ControlResponse.flow:type_name -> transport.v1.FlowControl
+	10, // 17: transport.v1.ControlResponse.error:type_name -> transport.v1.ControlError
+	12, // 18: transport.v1.FlowControl.partition_acks:type_name -> transport.v1.PartitionAck
+	1,  // 19: transport.v1.FlowControl.signal:type_name -> transport.v1.FlowControlSignal
+	3,  // 20: transport.v1.DataRequest.audio:type_name -> transport.v1.AudioFrame
+	4,  // 21: transport.v1.DataRequest.video:type_name -> transport.v1.VideoFrame
+	5,  // 22: transport.v1.DataRequest.binary:type_name -> transport.v1.BinaryFrame
+	24, // 23: transport.v1.DataRequest.metadata:type_name -> transport.v1.DataRequest.MetadataEntry
+	28, // 24: transport.v1.DataRequest.payload:type_name -> google.protobuf.Struct
+	28, // 25: transport.v1.DataRequest.inputs:type_name -> google.protobuf.Struct
+	6,  // 26: transport.v1.DataRequest.transports:type_name -> transport.v1.TransportDescriptor
+	14, // 27: transport.v1.DataRequest.envelope:type_name -> transport.v1.StreamEnvelope
+	3,  // 28: transport.v1.DataResponse.audio:type_name -> transport.v1.AudioFrame
+	4,  // 29: transport.v1.DataResponse.video:type_name -> transport.v1.VideoFrame
+	5,  // 30: transport.v1.DataResponse.binary:type_name -> transport.v1.BinaryFrame
+	25, // 31: transport.v1.DataResponse.metadata:type_name -> transport.v1.DataResponse.MetadataEntry
+	28, // 32: transport.v1.DataResponse.payload:type_name -> google.protobuf.Struct
+	28, // 33: transport.v1.DataResponse.inputs:type_name -> google.protobuf.Struct
+	6,  // 34: transport.v1.DataResponse.transports:type_name -> transport.v1.TransportDescriptor
+	14, // 35: transport.v1.DataResponse.envelope:type_name -> transport.v1.StreamEnvelope
+	26, // 36: transport.v1.HubPushRequest.metadata:type_name -> transport.v1.HubPushRequest.MetadataEntry
+	28, // 37: transport.v1.HubPushRequest.payload:type_name -> google.protobuf.Struct
+	28, // 38: transport.v1.HubPushRequest.inputs:type_name -> google.protobuf.Struct
+	3,  // 39: transport.v1.HubPushRequest.audio:type_name -> transport.v1.AudioFrame
+	4,  // 40: transport.v1.HubPushRequest.video:type_name -> transport.v1.VideoFrame
+	5,  // 41: transport.v1.HubPushRequest.binary:type_name -> transport.v1.BinaryFrame
+	6,  // 42: transport.v1.HubPushRequest.transports:type_name -> transport.v1.TransportDescriptor
+	14, // 43: transport.v1.HubPushRequest.envelope:type_name -> transport.v1.StreamEnvelope
+	27, // 44: transport.v1.HubPushResponse.metadata:type_name -> transport.v1.HubPushResponse.MetadataEntry
+	28, // 45: transport.v1.HubPushResponse.payload:type_name -> google.protobuf.Struct
+	28, // 46: transport.v1.HubPushResponse.inputs:type_name -> google.protobuf.Struct
+	6,  // 47: transport.v1.HubPushResponse.transports:type_name -> transport.v1.TransportDescriptor
+	3,  // 48: transport.v1.HubPushResponse.audio:type_name -> transport.v1.AudioFrame
+	4,  // 49: transport.v1.HubPushResponse.video:type_name -> transport.v1.VideoFrame
+	5,  // 50: transport.v1.HubPushResponse.binary:type_name -> transport.v1.BinaryFrame
+	14, // 51: transport.v1.HubPushResponse.envelope:type_name -> transport.v1.StreamEnvelope
+	16, // 52: transport.v1.TransportConnectorService.Data:input_type -> transport.v1.DataRequest
+	9,  // 53: transport.v1.TransportConnectorService.Control:input_type -> transport.v1.ControlRequest
+	18, // 54: transport.v1.TransportConnectorService.HubPush:input_type -> transport.v1.HubPushRequest
+	17, // 55: transport.v1.TransportConnectorService.Data:output_type -> transport.v1.DataResponse
+	11, // 56: transport.v1.TransportConnectorService.Control:output_type -> transport.v1.ControlResponse
+	19, // 57: transport.v1.TransportConnectorService.HubPush:output_type -> transport.v1.HubPushResponse
+	55, // [55:58] is the sub-list for method output_type
+	52, // [52:55] is the sub-list for method input_type
+	52, // [52:52] is the sub-list for extension type_name
+	52, // [52:52] is the sub-list for extension extendee
+	0,  // [0:52] is the sub-list for field type_name
 }
 
 func init() { file_transport_v1_transport_proto_init() }
@@ -2234,27 +2312,27 @@ func file_transport_v1_transport_proto_init() {
 	if File_transport_v1_transport_proto != nil {
 		return
 	}
-	file_transport_v1_transport_proto_msgTypes[4].OneofWrappers = []any{
+	file_transport_v1_transport_proto_msgTypes[5].OneofWrappers = []any{
 		(*PublishRequest_Audio)(nil),
 		(*PublishRequest_Video)(nil),
 		(*PublishRequest_Binary)(nil),
 	}
-	file_transport_v1_transport_proto_msgTypes[12].OneofWrappers = []any{
+	file_transport_v1_transport_proto_msgTypes[13].OneofWrappers = []any{
 		(*DataRequest_Audio)(nil),
 		(*DataRequest_Video)(nil),
 		(*DataRequest_Binary)(nil),
 	}
-	file_transport_v1_transport_proto_msgTypes[13].OneofWrappers = []any{
+	file_transport_v1_transport_proto_msgTypes[14].OneofWrappers = []any{
 		(*DataResponse_Audio)(nil),
 		(*DataResponse_Video)(nil),
 		(*DataResponse_Binary)(nil),
 	}
-	file_transport_v1_transport_proto_msgTypes[14].OneofWrappers = []any{
+	file_transport_v1_transport_proto_msgTypes[15].OneofWrappers = []any{
 		(*HubPushRequest_Audio)(nil),
 		(*HubPushRequest_Video)(nil),
 		(*HubPushRequest_Binary)(nil),
 	}
-	file_transport_v1_transport_proto_msgTypes[15].OneofWrappers = []any{
+	file_transport_v1_transport_proto_msgTypes[16].OneofWrappers = []any{
 		(*HubPushResponse_Audio)(nil),
 		(*HubPushResponse_Video)(nil),
 		(*HubPushResponse_Binary)(nil),
@@ -2265,7 +2343,7 @@ func file_transport_v1_transport_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_transport_v1_transport_proto_rawDesc), len(file_transport_v1_transport_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   24,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/transport/v1/transport.proto
+++ b/proto/transport/v1/transport.proto
@@ -119,7 +119,24 @@ message TransportDescriptor {
   // mode identifies how the transport is used (for example, hot vs cold path).
   string mode = 3 [(buf.validate.field).string.max_len = 128];
   // config contains transport-specific configuration surfaced to consumers.
+  // It is retained for compatibility with older producers and consumers. New
+  // consumers should prefer typed_config when present and must not use config
+  // values directly for connection, TLS, credential, or endpoint decisions
+  // without an allowlisted downstream validation step.
   google.protobuf.Struct config = 4;
+  // typed_config carries bounded runtime descriptor metadata. It intentionally
+  // excludes provider connection directives such as endpoints, credentials, or
+  // TLS-disable flags; those settings belong in validated operator-owned
+  // Transport/TransportBinding configuration, not in per-packet descriptors.
+  TransportConfig typed_config = 5;
+}
+
+// TransportConfig carries safe, typed runtime descriptor metadata.
+message TransportConfig {
+  // transport_ref identifies the Transport resource that produced this descriptor.
+  string transport_ref = 1 [(buf.validate.field).string.max_len = 253];
+  // mode_reason explains why the runtime selected the descriptor mode.
+  string mode_reason = 2 [(buf.validate.field).string.max_len = 512];
 }
 
 // PublishRequest carries a packet plus structured context for pub/sub style publishers.


### PR DESCRIPTION
## Summary
- add optional typed_config to TransportDescriptor while preserving legacy config field 4
- define bounded TransportConfig metadata for transport_ref and mode_reason
- add round-trip and protovalidate coverage for the typed config field

## Verification
- make generate
- make buf-lint
- make buf-breaking
- env GOCACHE=/tmp/bubustack-go-cache make test
- env GOCACHE=/tmp/bubustack-go-cache GOLANGCI_LINT_CACHE=/tmp/bubustack-golangci-lint-cache make lint

Closes #13